### PR TITLE
#137854845 Add README badges for CI, coveralls and scrutinizer 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # healthchecks
 
+[![Build Status](https://travis-ci.org/andela/healthchecks_spartans.svg?branch=readme_setup)](https://travis-ci.org/andela/healthchecks_spartans.svg?branch=readme_setup)
+
 ![Screenshot of Welcome page](/stuff/screenshots/welcome.png?raw=true "Welcome Page")
 
 ![Screenshot of My Checks page](/stuff/screenshots/my_checks.png?raw=true "My Checks Page")

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # healthchecks
 
 [![Build Status](https://travis-ci.org/andela/healthchecks_spartans.svg)](https://travis-ci.org/andela/healthchecks_spartans)
-[![Coverage Status](https://coveralls.io/repos/github/andela/healthchecks_spartans/badge.svg?branch=readme_setup)](https://coveralls.io/github/andela/healthchecks_spartans?branch=readme_setup)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/andela/healthchecks_spartans/badges/quality-score.png?b=dev)](https://scrutinizer-ci.com/g/andela/healthchecks_spartans/?branch=readme_setup)
+[![Coverage Status](https://coveralls.io/repos/github/andela/healthchecks_spartans/badge.svg?branch=readme_setup)](https://coveralls.io/github/andela/healthchecks_spartans?branch=Feature-Adds-README-Badges-137854845)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/andela/healthchecks_spartans/badges/quality-score.png?b=dev)](https://scrutinizer-ci.com/g/andela/healthchecks_spartans/?branch=Feature-Adds-README-Badges-137854845)
 
 ![Screenshot of Welcome page](/stuff/screenshots/welcome.png?raw=true "Welcome Page")
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/andela/healthchecks_spartans.svg)](https://travis-ci.org/andela/healthchecks_spartans)
 
+[![Coverage Status](https://coveralls.io/repos/github/andela/healthchecks_spartans/badge.svg)](https://coveralls.io/github/andela/healthchecks_spartans?branch=dev)
+
 ![Screenshot of Welcome page](/stuff/screenshots/welcome.png?raw=true "Welcome Page")
 
 ![Screenshot of My Checks page](/stuff/screenshots/my_checks.png?raw=true "My Checks Page")

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # healthchecks
 
 [![Build Status](https://travis-ci.org/andela/healthchecks_spartans.svg)](https://travis-ci.org/andela/healthchecks_spartans)
-
-[![Coverage Status](https://coveralls.io/repos/github/andela/healthchecks_spartans/badge.svg)](https://coveralls.io/github/andela/healthchecks_spartans?branch=dev)
+[![Coverage Status](https://coveralls.io/repos/github/andela/healthchecks_spartans/badge.svg)](https://coveralls.io/github/andela/healthchecks_spartans)
 
 ![Screenshot of Welcome page](/stuff/screenshots/welcome.png?raw=true "Welcome Page")
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # healthchecks
 
-[![Build Status](https://travis-ci.org/andela/healthchecks_spartans.svg?branch=readme_setup)](https://travis-ci.org/andela/healthchecks_spartans.svg?branch=readme_setup)
+[![Build Status](https://travis-ci.org/andela/healthchecks_spartans.svg)](https://travis-ci.org/andela/healthchecks_spartans)
 
 ![Screenshot of Welcome page](/stuff/screenshots/welcome.png?raw=true "Welcome Page")
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # healthchecks
 
 [![Build Status](https://travis-ci.org/andela/healthchecks_spartans.svg)](https://travis-ci.org/andela/healthchecks_spartans)
-[![Coverage Status](https://coveralls.io/repos/github/andela/healthchecks_spartans/badge.svg?branch=readme_setup)](https://coveralls.io/github/andela/healthchecks_spartans?branch=Feature-Adds-README-Badges-137854845)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/andela/healthchecks_spartans/badges/quality-score.png?b=dev)](https://scrutinizer-ci.com/g/andela/healthchecks_spartans/?branch=Feature-Adds-README-Badges-137854845)
+[![Coverage Status](https://coveralls.io/repos/github/andela/healthchecks_spartans/badge.svg?branch=dev)](https://coveralls.io/github/andela/healthchecks_spartans?branch=dev)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/andela/healthchecks_spartans/badges/quality-score.png?b=dev)](https://scrutinizer-ci.com/g/andela/healthchecks_spartans/?branch=dev)
 
 ![Screenshot of Welcome page](/stuff/screenshots/welcome.png?raw=true "Welcome Page")
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # healthchecks
 
 [![Build Status](https://travis-ci.org/andela/healthchecks_spartans.svg)](https://travis-ci.org/andela/healthchecks_spartans)
-[![Coverage Status](https://coveralls.io/repos/github/andela/healthchecks_spartans/badge.svg)](https://coveralls.io/github/andela/healthchecks_spartans)
-
+[![Coverage Status](https://coveralls.io/repos/github/andela/healthchecks_spartans/badge.svg?branch=readme_setup)](https://coveralls.io/github/andela/healthchecks_spartans?branch=readme_setup)
 ![Screenshot of Welcome page](/stuff/screenshots/welcome.png?raw=true "Welcome Page")
 
 ![Screenshot of My Checks page](/stuff/screenshots/my_checks.png?raw=true "My Checks Page")

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/andela/healthchecks_spartans.svg)](https://travis-ci.org/andela/healthchecks_spartans)
 [![Coverage Status](https://coveralls.io/repos/github/andela/healthchecks_spartans/badge.svg?branch=readme_setup)](https://coveralls.io/github/andela/healthchecks_spartans?branch=readme_setup)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/andela/healthchecks_spartans/badges/quality-score.png?b=dev)](https://scrutinizer-ci.com/g/andela/healthchecks_spartans/?branch=readme_setup)
+
 ![Screenshot of Welcome page](/stuff/screenshots/welcome.png?raw=true "Welcome Page")
 
 ![Screenshot of My Checks page](/stuff/screenshots/my_checks.png?raw=true "My Checks Page")


### PR DESCRIPTION
Adds status badges on the project README file for continuous integration service (Travis), Coveralls for code coverage and scrutinizer to check code quality.

**How should this be manually tested?**

Click on the badges to see the various statuses of the project.

**What are the relevant Pivotal Tracker stories?**
#137854845